### PR TITLE
updated for pimcore 5.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,14 @@ See example: [toc.js](https://github.com/pimcore/web2print-tools/blob/master/Res
 See full documentation and examples: [pdfreactor-manual](http://www.pdfreactor.com/product/doc/manual.pdf)
 
 
+## Running with Pimcore < 5.4
+With Pimcore 5.4 the location of static Pimcore files like icons has changed. In order to make this bundle work 
+with Pimcore < 5.4, please add following rewrite rule to your `.htaccess`.
+```
+    # rewrite rule for pre pimcore 5.4 core static files
+    RewriteRule ^bundles/pimcoreadmin/(.*) /pimcore/static6/$1 [PT,L]
+``` 
+
 # Migration from Pimcore 4
 - change table name from `plugin_web2print_favorite_outputdefinitions` to `bundle_web2print_favorite_outputdefinitions`
 ```sql

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "sort-packages": true
   },
   "require": {
-    "pimcore/core-version": ">=5.2.0 <5.4",
+    "pimcore/core-version": ">=5.2.0 <5.5",
     "pimcore/output-data-config-toolkit-bundle": "~2"
   },
   "autoload": {

--- a/src/Resources/public/css/admin.css
+++ b/src/Resources/public/css/admin.css
@@ -13,7 +13,7 @@
 
 
 .bundle_outputdataconfig_icon {
-    background: url("/pimcore/static6/img/flat-color-icons/grid.svg") center center no-repeat !important;
+    background: url("/bundles/pimcoreadmin/img/flat-color-icons/grid.svg") center center no-repeat !important;
 }
 .bundle_outputdataconfig_icon_overlay:before {
     position: absolute;
@@ -22,15 +22,15 @@
     bottom: 0px;
     right: 0px;
     content: "";
-    background: url(/pimcore/static6/img/flat-color-icons/go.svg) center center no-repeat !important;
+    background: url(/bundles/pimcoreadmin/img/flat-color-icons/go.svg) center center no-repeat !important;
 }
 
 #pimcore_menu_web2print {
-    background-image: url("/pimcore/static6/img/flat-color-icons/news.svg") !important;
+    background-image: url("/bundles/pimcoreadmin/img/flat-color-icons/news.svg") !important;
 }
 
 .bundle_web2print_custom_areas {
-    background: url("/pimcore/static6/img/flat-color-icons/area.svg") center center no-repeat !important;
+    background: url("/bundles/pimcoreadmin/img/flat-color-icons/area.svg") center center no-repeat !important;
 }
 .bundle_web2print_custom_areas_overlay:before {
     position: absolute;
@@ -39,24 +39,24 @@
     bottom: 0px;
     right: 0px;
     content: "";
-    background: url(/pimcore/static6/img/flat-color-icons/star.svg) center center no-repeat !important;
+    background: url(/bundles/pimcoreadmin/img/flat-color-icons/star.svg) center center no-repeat !important;
 }
 
 
 
 
 .bundle_web2print_customAreas_config, .bundle_web2print_custom_area_icon {
-    background: url(/pimcore/static6/img/icon/layout_content.png) left center no-repeat !important;
+    background: url(/bundles/pimcoreadmin/img/icon/layout_content.png) left center no-repeat !important;
 }
 
 
 
 
 .bundle_web2print_customarea_file_css {
-    background: url(/pimcore/static6/img/icon/css.png) left center no-repeat !important;
+    background: url(/bundles/pimcoreadmin/img/icon/css.png) left center no-repeat !important;
 }
 
 .bundle_web2print_customarea_file_php {
-    background: url(/pimcore/static6/img/icon/html.png) left center no-repeat !important;
+    background: url(/bundles/pimcoreadmin/img/icon/html.png) left center no-repeat !important;
 }
 

--- a/src/Resources/public/js/Web2Print/favoriteOutputDefinitions.js
+++ b/src/Resources/public/js/Web2Print/favoriteOutputDefinitions.js
@@ -136,7 +136,7 @@ pimcore.bundle.web2print.favoriteOutputDefinitionsTable = Class.create({
             items: [
                 {
                     tooltip: t('remove'),
-                    icon: "/pimcore/static6/img/flat-color-icons/delete.svg",
+                    icon: "/bundles/pimcoreadmin/img/flat-color-icons/delete.svg",
                     handler: function (grid, rowIndex) {
                         grid.getStore().removeAt(rowIndex);
                     }.bind(this)

--- a/src/Resources/public/js/pimcore/document/tags/metaentry/table.js
+++ b/src/Resources/public/js/pimcore/document/tags/metaentry/table.js
@@ -72,7 +72,7 @@ pimcore.document.tags.metaentry.table = Class.create(pimcore.document.tags.metae
                     items: [
                         {
                             tooltip: t('remove'),
-                            icon: "/pimcore/static6/img/flat-color-icons/delete.svg",
+                            icon: "/bundles/pimcoreadmin/img/flat-color-icons/delete.svg",
                             handler: function (grid, rowIndex) {
                                 grid.getStore().removeAt(rowIndex);
                             }.bind(this)

--- a/src/Resources/public/js/pimcore/document/tags/outputchanneltable.js
+++ b/src/Resources/public/js/pimcore/document/tags/outputchanneltable.js
@@ -108,7 +108,7 @@ pimcore.document.tags.outputchanneltable = Class.create(pimcore.document.tag, {
                         width: 40,
                         items: [{
                             tooltip: t('open'),
-                            icon: "/pimcore/static6/img/flat-color-icons/cursor.svg",
+                            icon: "/bundles/pimcoreadmin/img/flat-color-icons/cursor.svg",
                             handler: function (grid, rowIndex) {
                                 var data = grid.getStore().getAt(rowIndex);
 
@@ -129,7 +129,7 @@ pimcore.document.tags.outputchanneltable = Class.create(pimcore.document.tag, {
                         width: 40,
                         items: [{
                             tooltip: t('remove'),
-                            icon: "/pimcore/static6/img/flat-color-icons/delete.svg",
+                            icon: "/bundles/pimcoreadmin/img/flat-color-icons/delete.svg",
                             handler: function (grid, rowIndex) {
                                 grid.getStore().removeAt(rowIndex);
                             }.bind(this)


### PR DESCRIPTION
## For running with Pimcore < 5.4
With Pimcore 5.4 the location of static Pimcore files like icons has changed. In order to make this bundle work with Pimcore < 5.4, please add following rewrite rule to your `.htaccess`.
```
    # rewrite rule for pre pimcore 5.4 core static files
    RewriteRule ^bundles/pimcoreadmin/(.*) /pimcore/static6/$1 [PT,L]
``` 
