### PR TITLE
Save as existing favorite output definition not possible

### DIFF
--- a/src/Resources/public/js/Web2Print/saveAsFavouriteOutputDefinitionDialog.js
+++ b/src/Resources/public/js/Web2Print/saveAsFavouriteOutputDefinitionDialog.js
@@ -30,7 +30,7 @@ pimcore.bundle.web2print.SaveAsFavouriteOutputDefinitionDialog = Class.create({
             disabled: true,
             store: new Ext.data.JsonStore({
                 proxy: {
-                    url: '/admin/outputdataconfig/admin/favorite-output-definitions',
+                    url: '/admin/web2printtools/admin/favorite-output-definitions',
                     type: 'ajax',
                     reader: {
                         type: 'json',


### PR DESCRIPTION
Currently output definitions can not be save as an existing definition as the combo box uses a route, which does not exist anymore. The route was changed due to the new naming scheme to address this issue.