### PR TITLE
[Bug]: Replace deprecated `getO_Id` with `getId()`

### DIFF
--- a/src/Model/Document/Editable/Outputchanneltable.php
+++ b/src/Model/Document/Editable/Outputchanneltable.php
@@ -242,10 +242,10 @@ class Outputchanneltable extends Document\Editable implements \Iterator
         if (is_array($this->elements) && count($this->elements) > 0) {
             foreach ($this->elements as $element) {
                 if ($element instanceof \Pimcore\Model\DataObject\AbstractObject) {
-                    $key = 'object_' . $element->getO_Id();
+                    $key = 'object_' . $element->getId();
 
                     $dependencies[$key] = [
-                        'id' => $element->getO_Id(),
+                        'id' => $element->getId(),
                         'type' => 'object'
                     ];
                 }


### PR DESCRIPTION
Basing on https://github.com/pimcore/pimcore/commit/ea93fcfc53bf71bcb260792d5821dd8e6f87c0e4 It seems some pre-refactoring leftovers