### PR TITLE
[Task]: Fix Installer dump

### DIFF
--- a/src/FavoriteOutputDefinition/Dao.php
+++ b/src/FavoriteOutputDefinition/Dao.php
@@ -99,7 +99,6 @@ class Dao extends \Pimcore\Model\Dao\AbstractDao
             }
         }
 
-        $data['id'] = $this->model->getId();
         Helper::insertOrUpdate($this->db, self::TABLE_NAME, $data);
     }
 

--- a/src/FavoriteOutputDefinition/Dao.php
+++ b/src/FavoriteOutputDefinition/Dao.php
@@ -94,6 +94,8 @@ class Dao extends \Pimcore\Model\Dao\AbstractDao
                 $data[$key] = $value;
             }
         }
+
+        $data['id'] = $this->model->getId();
         Helper::insertOrUpdate($this->db, self::TABLE_NAME, $data);
     }
 

--- a/src/Tools/Installer.php
+++ b/src/Tools/Installer.php
@@ -29,8 +29,8 @@ class Installer extends SettingsStoreAwareInstaller
         $db->executeQuery('
             CREATE TABLE IF NOT EXISTS `' . Dao::TABLE_NAME . '` (
               `id` int(11) NOT NULL AUTO_INCREMENT,
-              `o_classId` varchar(50) NOT NULL,
-              `description` varchar(255) COLLATE utf8_bin NOT NULL,
+              `o_classId` varchar(50) NULL,
+              `description` varchar(255) COLLATE utf8_bin NULL,
               `configuration` longtext CHARACTER SET latin1,
               PRIMARY KEY (`id`)
             ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin;


### PR DESCRIPTION
Follow-up of https://github.com/pimcore/web2print-tools/pull/33
~Requires https://github.com/pimcore/web2print-tools/pull/44 to pass tests~

The migration is fine but the installer should execute the "final" table query on fresh installation, right?
https://github.com/pimcore/web2print-tools/pull/33/files#diff-debbb88a92aea985c659724df6a576939223d5f5312165793ecec7d17a45397c
