### PR TITLE
Add required __sleep type hint

### DIFF
--- a/src/Model/Document/Editable/Outputchanneltable.php
+++ b/src/Model/Document/Editable/Outputchanneltable.php
@@ -239,10 +239,7 @@ class Outputchanneltable extends Document\Editable implements \Iterator
         return [];
     }
 
-    /**
-     * @return array
-     */
-    public function __sleep()
+    public function __sleep(): array
     {
         $finalVars = [];
         $parentVars = parent::__sleep();


### PR DESCRIPTION
Is required because the parent class has also this type hint.