### PR TITLE
[Bug]: Fix support for textual `classId` not being quoted

### DIFF
--- a/src/Controller/AdminController.php
+++ b/src/Controller/AdminController.php
@@ -115,7 +115,7 @@ class AdminController extends \Pimcore\Bundle\AdminBundle\Controller\AdminContro
         $list = new FavoriteOutputDefinition\Listing();
         $list->setOrder('asc');
         $list->setOrderKey('description');
-        $condition = 'o_classId = ' . $request->get('classId');
+        $condition = 'o_classId = ' . $list->quote($request->get('classId'));
         $list->setCondition($condition);
 
         $definitions = [];


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/6014195/236464206-0737dd52-3be2-4380-b97f-551bf93aac0a.png)
To reproduce: using the editable, this `overwrite existing` would not display any configuration