### PR TITLE
[Bug]: Add EditmodeDataInterface to Output Channel Table editable

### DIFF
--- a/src/Model/Document/Editable/Outputchanneltable.php
+++ b/src/Model/Document/Editable/Outputchanneltable.php
@@ -18,6 +18,7 @@ namespace Web2PrintToolsBundle\Model\Document\Editable;
 use OutputDataConfigToolkitBundle\OutputDefinition;
 use Pimcore\Model\Document;
 use Pimcore\Model\Document\Editable\EditableInterface;
+use Pimcore\Model\Document\Editable\EditmodeDataInterface;
 use Pimcore\Model\Element\ElementDescriptor;
 use Web2PrintToolsBundle\Model\Document\Editable\Outputchanneltable\MetaEntry;
 

--- a/src/Model/Document/Editable/Outputchanneltable.php
+++ b/src/Model/Document/Editable/Outputchanneltable.php
@@ -21,7 +21,7 @@ use Pimcore\Model\Document\Editable\EditableInterface;
 use Pimcore\Model\Element\ElementDescriptor;
 use Web2PrintToolsBundle\Model\Document\Editable\Outputchanneltable\MetaEntry;
 
-class Outputchanneltable extends Document\Editable implements \Iterator
+class Outputchanneltable extends Document\Editable implements \Iterator, EditmodeDataInterface
 {
     /**
      * @var array


### PR DESCRIPTION
When using this editable and setting some data and save, it would not load again.
This is likely due a change of https://github.com/pimcore/pimcore/pull/10607 and by not having that interface, it would use `getData()` instead of `getDataEditmode()`
See also https://github.com/pimcore/pimcore/blob/5f3de5110b90ea4acbd7e6ec86e7c48a9b67cb12/models/Document/Editable.php#L164-L168

~ToDo: check if bundle 4.x with Pimcore 10.x is affected.~ 10.x is fine, the removal of the bc layer happened in 11
