### PR TITLE
[Bug]: migration fails for classid column for Pimcore 11

### DIFF
--- a/src/Migrations/PimcoreX/Version20220914092411.php
+++ b/src/Migrations/PimcoreX/Version20220914092411.php
@@ -51,14 +51,13 @@ class Version20220914092411 extends BundleAwareMigration
 
     private function getClassIdColumn(Schema $schema): ?string
     {
-        $columnName = null;
         $table = $schema->getTable(DAO::TABLE_NAME);
         if ($table->hasColumn('o_classid')) {
-            $columnName = 'o_classid';
+            return 'o_classid';
         } elseif ($table->hasColumn('classId')) {
-            $columnName = 'classId';
+            return 'classId';
         }
 
-        return $columnName;
+        return null;
     }
 }

--- a/src/Migrations/PimcoreX/Version20220914092411.php
+++ b/src/Migrations/PimcoreX/Version20220914092411.php
@@ -33,14 +33,32 @@ class Version20220914092411 extends BundleAwareMigration
     public function up(Schema $schema): void
     {
         $db = Db::get();
-        $this->addSql('alter table ' . $db->quoteIdentifier(DAO::TABLE_NAME) . ' modify o_classid varchar(50) null');
+
+        if ($column = $this->getClassIdColumn($schema)) {
+            $this->addSql('alter table ' . $db->quoteIdentifier(DAO::TABLE_NAME) . ' modify ' . $column .' varchar(50) null');
+        }
         $this->addSql('alter table ' . $db->quoteIdentifier(DAO::TABLE_NAME) . ' modify ' . $db->quoteIdentifier('description') . ' varchar(255) null');
     }
 
     public function down(Schema $schema): void
     {
         $db = Db::get();
-        $this->addSql('alter table ' . $db->quoteIdentifier(DAO::TABLE_NAME) . ' modify o_classid varchar(50) not null');
+        if ($column = $this->getClassIdColumn($schema)) {
+            $this->addSql('alter table ' . $db->quoteIdentifier(DAO::TABLE_NAME) . ' modify ' . $column .' varchar(50) not null');
+        }
         $this->addSql('alter table ' . $db->quoteIdentifier(DAO::TABLE_NAME) . ' modify ' . $db->quoteIdentifier('description') . ' varchar(255) not null;');
+    }
+
+    private function getClassIdColumn(Schema $schema): ?string
+    {
+        $columnName = null;
+        $table = $schema->getTable(DAO::TABLE_NAME);
+        if ($table->hasColumn('o_classid')) {
+            $columnName = 'o_classid';
+        } elseif ($table->hasColumn('classId')) {
+            $columnName = 'classId';
+        }
+
+        return $columnName;
     }
 }


### PR DESCRIPTION
When updating from pimcore 10.6 to 11 migration fails due to a change in the column name

<img width="707" alt="Screenshot 2023-05-11 092313" src="https://github.com/pimcore/web2print-tools/assets/30526586/9b6cc7e3-668e-4b4a-8153-3955b2d40e7e">

This should fix it.