### PR TITLE
[Bug]: Refactor migration to `CHANGE COLUMN` instead of `RENAME`

### DIFF
--- a/src/Migrations/PimcoreX/Version20230124103907.php
+++ b/src/Migrations/PimcoreX/Version20230124103907.php
@@ -37,7 +37,7 @@ final class Version20230124103907 extends AbstractMigration
 
         if ($table->hasColumn('o_classId')) {
             $this->addSql(sprintf(
-                'ALTER TABLE `%s` RENAME COLUMN `%s` TO `%s`',
+                'ALTER TABLE `%s` CHANGE COLUMN `%s` `%s` varchar(50) NULL',
                 $table->getName(),
                 'o_classId',
                 'classId'
@@ -51,7 +51,7 @@ final class Version20230124103907 extends AbstractMigration
 
         if ($table->hasColumn('classId')) {
             $this->addSql(sprintf(
-                'ALTER TABLE `%s` RENAME COLUMN `%s` TO `%s`',
+                'ALTER TABLE `%s` CHANGE COLUMN `%s` `%s` varchar(50) NULL',
                 $table->getName(),
                 'classId',
                 'o_classId'


### PR DESCRIPTION
Rename column is only introduced in MariaDB 10.5, minimum requirement of MariaDB is 10.3
See also https://github.com/pimcore/web2print-tools/issues/78#issuecomment-1596683953