### PR TITLE
Fixed getting class from store for getting proper configurations

### DIFF
--- a/src/Resources/public/js/pimcore/document/editables/outputchanneltable.js
+++ b/src/Resources/public/js/pimcore/document/editables/outputchanneltable.js
@@ -467,7 +467,7 @@ pimcore.document.editables.outputchanneltable = Class.create(pimcore.document.ed
 
     getCurrentClassId: function() {
         var classStore = pimcore.globalmanager.get("object_types_store");
-        var index = classStore.find("text", this.selectedClass);
+        var index = classStore.find("text", this.selectedClass, 0, false, false, true);
         if(typeof index !== 'undefined'  && classStore.getAt(index)) {
             return classStore.getAt(index).id;
         }


### PR DESCRIPTION
Hi!

Looks like bundle has the same issue that reported  in https://github.com/pimcore/advanced-object-search/issues/223#issue-1764796831 - if you have 2 classes that starts from the same name - Product and ProductPrice - function "find" extJS return wrong item and if you choose "Product", you'll get  "ProductPrice" class instead.

PR contains fix with populating all params  and getting expected result to strict.

Please review,