### PR TITLE
[Bugfix] Fix description cannot be null

### DIFF
--- a/src/FavoriteOutputDefinition.php
+++ b/src/FavoriteOutputDefinition.php
@@ -26,7 +26,7 @@ class FavoriteOutputDefinition extends \Pimcore\Model\AbstractModel
 
     public $classId;
 
-    public $description;
+    public $description = '';
 
     public $configuration;
 


### PR DESCRIPTION
While trying to add a new definition following error occurs

```bash
Timestamp: Tue Nov 19 2024 11:18:25 GMT+0100 (Central European Standard Time)
Status: 500 | Internal Server Error
URL: /admin/web2printtools/admin/favorite-output-definitions-table-proxy?xaction=create&_dc=1732011504866
Method: POST
Message: An exception occurred while executing a query: SQLSTATE[23000]: Integrity constraint violation: 1048 Column 'description' cannot be null
Trace: 
in /var/www/html/vendor/doctrine/dbal/src/Driver/API/MySQL/ExceptionConverter.php:115
#0 /var/www/html/vendor/doctrine/dbal/src/Connection.php(1939): Doctrine\DBAL\Driver\API\MySQL\ExceptionConverter->convert(Object(Doctrine\DBAL\Driver\PDO\Exception), Object(Doctrine\DBAL\Query))
#1 /var/www/html/vendor/doctrine/dbal/src/Connection.php(1881): Doctrine\DBAL\Connection->handleDriverException(Object(Doctrine\DBAL\Driver\PDO\Exception), Object(Doctrine\DBAL\Query))
#2 /var/www/html/vendor/doctrine/dbal/src/Connection.php(1213): Doctrine\DBAL\Connection->convertExceptionDuringQuery(Object(Doctrine\DBAL\Driver\PDO\Exception), 'INSERT INTO bun...', Array, Array)
#3 /var/www/html/vendor/doctrine/dbal/src/Connection.php(809): Doctrine\DBAL\Connection->executeStatement('INSERT INTO bun...', Array, Array)
#4 /var/www/html/dev/pimcore/pimcore/lib/Db/Helper.php(41): Doctrine\DBAL\Connection->insert('bundle_web2prin...', Array)
#5 /var/www/html/dev/pimcore/web2print-tools/src/FavoriteOutputDefinition/Dao.php(102): Pimcore\Db\Helper::upsert(Object(Doctrine\DBAL\Connection), 'bundle_web2prin...', Array, Array)
#6 /var/www/html/dev/pimcore/web2print-tools/src/FavoriteOutputDefinition/Dao.php(76): Web2PrintToolsBundle\FavoriteOutputDefinition\Dao->update()
#7 /var/www/html/dev/pimcore/web2print-tools/src/FavoriteOutputDefinition/Dao.php(67): Web2PrintToolsBundle\FavoriteOutputDefinition\Dao->save()
#8 /var/www/html/dev/pimcore/web2print-tools/src/FavoriteOutputDefinition/Dao.php(78): Web2PrintToolsBundle\FavoriteOutputDefinition\Dao->create()
#9 /var/www/html/dev/pimcore/web2print-tools/src/FavoriteOutputDefinition.php(69): Web2PrintToolsBundle\FavoriteOutputDefinition\Dao->save()
#10 /var/www/html/dev/pimcore/web2print-tools/src/Controller/AdminController.php(70): Web2PrintToolsBundle\FavoriteOutputDefinition->save()
#11 /var/www/html/vendor/symfony/http-kernel/HttpKernel.php(181): Web2PrintToolsBundle\Controller\AdminController->favoriteOutputDefinitionsTableProxyAction(Object(Symfony\Component\HttpFoundation\Request))
#12 /var/www/html/vendor/symfony/http-kernel/HttpKernel.php(76): Symfony\Component\HttpKernel\HttpKernel->handleRaw(Object(Symfony\Component\HttpFoundation\Request), 1)
#13 /var/www/html/vendor/symfony/http-kernel/Kernel.php(197): Symfony\Component\HttpKernel\HttpKernel->handle(Object(Symfony\Component\HttpFoundation\Request), 1, true)
#14 /var/www/html/vendor/symfony/runtime/Runner/Symfony/HttpKernelRunner.php(35): Symfony\Component\HttpKernel\Kernel->handle(Object(Symfony\Component\HttpFoundation\Request))
#15 /var/www/html/vendor/autoload_runtime.php(29): Symfony\Component\Runtime\Runner\Symfony\HttpKernelRunner->run()
#16 /var/www/html/public/index.php(20): require_once('/var/www/html/v...')
#17 {main}
```