### PR TITLE
CI: consolidated workflow fixes (php-cs-fixer pwn-request, dead static-analysis reference, trigger hygiene)

### DIFF
--- a/.github/workflows/php-cs-fixer.yaml
+++ b/.github/workflows/php-cs-fixer.yaml
@@ -1,35 +1,23 @@
 name: "PHP-CS-Fixer"
 
 on:
-    pull_request_target:
-        branches:
-            - "[0-9]+.[0-9]+"
-            - "[0-9]+.x"
-            - "feature-*"
-    push:
-        branches:
-            - "[0-9]+.[0-9]+"
-            - "[0-9]+.x"
-            - "*_actions"
-            - "feature-*"
+  workflow_dispatch:
+  push:
+    branches:
+      - "[0-9]+.[0-9]+"
+      - "[0-9]+.x"
+      - "*_actions"
+      - "feature-*"
 
 permissions:
-    contents: read
+  contents: write
 
 jobs:
-    php-cs-fixer:
-        permissions:
-            contents: write  # for stefanzweifel/git-auto-commit-action to push code in repo
-        runs-on: ubuntu-latest
-        steps:
-            - uses: actions/checkout@v4
-              with:
-                  ref: ${{ github.event.pull_request.head.ref }}
-                  repository: ${{ github.event.pull_request.head.repo.full_name }}
-
-            - name: PHP-CS-Fixer
-              uses: docker://oskarstark/php-cs-fixer-ga:latest
-
-            - uses: stefanzweifel/git-auto-commit-action@v5
-              with:
-                  commit_message: Apply php-cs-fixer changes
+  php-style:
+    uses: pimcore/workflows-collection-public/.github/workflows/reusable-php-cs-fixer.yaml@main
+    with:
+      head_ref: ${{ github.head_ref || github.ref_name }}
+      repository: ${{ github.repository }}
+      config_file: ".php-cs-fixer.dist.php"
+    secrets:
+      PHP_CS_FIXER_GITHUB_TOKEN: ${{ secrets.PHP_CS_FIXER_GITHUB_TOKEN }}

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -1,95 +1,86 @@
 name: "Static analysis centralised"
 
 on:
-    schedule:
-        -   cron: '0 3 * * 1,3,5'
-    workflow_dispatch:
-    push:
-        branches:
-            - "[0-9]+.[0-9]+"
-            - "[0-9]+.x"
-            - "feature-*"
-    pull_request:
-        types: [ opened, synchronize, reopened ]
-
+  schedule:
+    - cron: '0 3 * * 1,3,5'
+  workflow_dispatch:
+  pull_request:
+    types: [ opened, synchronize, reopened ]
+    paths-ignore:
+      - 'doc/**'
+      - 'src/Resources/public/**'
+      - '**.md'
+  push:
+    paths-ignore:
+      - 'doc/**'
+      - 'src/Resources/public/**'
+      - '**.md'
+    branches:
+      - "[0-9]+.[0-9]+"
+      - "[0-9]+.x"
 
 env:
-    PIMCORE_PROJECT_ROOT: ${{ github.workspace }}
-    PRIVATE_REPO: ${{ github.event.repository.private }}
+  PIMCORE_PROJECT_ROOT: ${{ github.workspace }}
+  PRIVATE_REPO: ${{ github.event.repository.private }}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
+  cancel-in-progress: true
 
 jobs:
-    setup-matrix:
-        runs-on: ubuntu-latest
-        outputs:
-            php_versions: ${{ steps.parse-php-versions.outputs.php_versions }}
-            matrix: ${{ steps.set-matrix.outputs.matrix }}
-            private_repo: ${{ env.PRIVATE_REPO }}
-        steps:
-            - name: Checkout code
-              uses: actions/checkout@v4
+  setup-matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      php_versions: ${{ steps.parse-php-versions.outputs.php_versions }}
+      phpstan_matrix: ${{ steps.set-matrix.outputs.phpstan_matrix }}
+      private_repo: ${{ env.PRIVATE_REPO }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
 
-            - name: Checkout reusable workflow repo
-              uses: actions/checkout@v4
-              with:
-                  repository: pimcore/workflows-collection-public
-                  ref: main
-                  path: reusable-workflows
-
-            - name: Parse PHP versions from composer.json
-              id: parse-php-versions
-              run: |
-                  if [ -f composer.json ]; then
-                    php_versions=$(jq -r '.require.php' composer.json | grep -oP '\d+\.\d+' | tr '\n' ',' | sed 's/,$//')
-                    if [ -z "$php_versions" ]; then
-                      echo "No PHP versions found in composer.json"
-                      echo "Setting default PHP value"
-                      echo "php_versions=default" >> $GITHUB_OUTPUT
-                    else
-                      echo "php_versions=$php_versions" >> $GITHUB_OUTPUT
-                      echo "#### php versions #### : $php_versions"
-                    fi
-                  else
-                    echo "composer.json not found"
-                    exit 1
-                  fi
-
-            - name: Set up matrix
-              id: set-matrix
-              run: |
-                  php_versions="${{ steps.parse-php-versions.outputs.php_versions }}"
-                  
-                  MATRIX_JSON=$(cat reusable-workflows/phpstan-configuration/matrix-config.json)
-                  
-                  IFS=',' read -ra VERSIONS_ARRAY <<< "$php_versions"
-                  
-                  FILTERED_MATRIX_JSON=$(echo $MATRIX_JSON | jq --arg php_versions "$php_versions" '
-                  {
-                    matrix: [
-                      .configs[] |
-                      select(.php_version == $php_versions) |
-                      .matrix[]
-                    ]
-                  }')
-                  
-                  ENCODED_MATRIX_JSON=$(echo $FILTERED_MATRIX_JSON | jq -c .)
-                  
-                  echo "matrix=${ENCODED_MATRIX_JSON}" >> $GITHUB_OUTPUT
-
-    static-analysis:
-        needs: setup-matrix
-        strategy:
-            matrix: ${{ fromJson(needs.setup-matrix.outputs.matrix) }}
-        uses: pimcore/workflows-collection-public/.github/workflows/reusable-static-analysis-centralized.yaml@main
+      - name: Checkout reusable workflow repo
+        uses: actions/checkout@v4
         with:
-            APP_ENV: test
-            PIMCORE_TEST: 1
-            PRIVATE_REPO: ${{ needs.setup-matrix.outputs.private_repo}}
-            PHP_VERSION: ${{ matrix.matrix.php-version }}
-            SYMFONY: ${{ matrix.matrix.symfony }}
-            DEPENDENCIES: ${{ matrix.matrix.dependencies }}
-            EXPERIMENTAL: ${{ matrix.matrix.experimental }}
-            PIMCORE_VERSION: ${{ matrix.matrix.pimcore_version }}
-            COMPOSER_OPTIONS: ${{ matrix.matrix.composer_options }}
-        secrets:
-            SSH_PRIVATE_KEY_PIMCORE_DEPLOYMENTS_USER: ${{ secrets.SSH_PRIVATE_KEY_PIMCORE_DEPLOYMENTS_USER }}
-            COMPOSER_PIMCORE_REPO_PACKAGIST_TOKEN: ${{ secrets.COMPOSER_PIMCORE_REPO_PACKAGIST_TOKEN }}
+          repository: pimcore/workflows-collection-public
+          ref: main
+          path: reusable-workflows
+
+      - name: Parse PHP versions from composer.json
+        id: parse-php-versions
+        run: |
+          if [ -f composer.json ]; then
+            php_versions=$(jq -r '.require.php' composer.json | grep -oP '\d+\.\d+' | tr '\n' ',' | sed 's/,$//')
+            if [ -z "$php_versions" ]; then
+              echo "php_versions=default" >> "$GITHUB_OUTPUT"
+            else
+              echo "php_versions=$php_versions" >> "$GITHUB_OUTPUT"
+            fi
+          else
+            exit 1
+          fi
+
+      - name: Set up matrix JSON
+        id: set-matrix
+        run: |
+          php_versions="${{ steps.parse-php-versions.outputs.php_versions }}"
+          MATRIX_JSON=$(cat reusable-workflows/phpstan-configuration/matrix-config.json)
+          FILTERED_MATRIX_JSON=$(echo "$MATRIX_JSON" | jq --arg php_versions "$php_versions" '{ include: [ .configs[] | select(.php_version == $php_versions) | .matrix[] ] }')
+          ENCODED_MATRIX_JSON=$(echo "$FILTERED_MATRIX_JSON" | jq -c .)
+          echo "phpstan_matrix=$ENCODED_MATRIX_JSON" >> "$GITHUB_OUTPUT"
+
+  static-analysis:
+    needs: setup-matrix
+    uses: pimcore/workflows-collection-public/.github/workflows/reusable-static-analysis-unified.yaml@main
+    with:
+      phpstan_matrix: ${{ needs.setup-matrix.outputs.phpstan_matrix }}
+      private_repo: ${{ needs.setup-matrix.outputs.private_repo }}
+      APP_ENV: test
+      PIMCORE_TEST: 1
+      REQUIRE_ADMIN_BUNDLE: "true"
+      COVERAGE: "none"
+    secrets:
+      SSH_PRIVATE_KEY_PIMCORE_DEPLOYMENTS_USER: ${{ secrets.SSH_PRIVATE_KEY_PIMCORE_DEPLOYMENTS_USER }}
+      COMPOSER_PIMCORE_REPO_PACKAGIST_TOKEN: ${{ secrets.COMPOSER_PIMCORE_REPO_PACKAGIST_TOKEN }}
+      PIMCORE_CI_INSTANCE_IDENTIFIER: ${{ secrets.PIMCORE_CI_INSTANCE_IDENTIFIER }}
+      PIMCORE_CI_ENCRYPTION_SECRET: ${{ secrets.PIMCORE_CI_ENCRYPTION_SECRET }}
+      PIMCORE_CI_PRODUCT_KEY: ${{ secrets.PIMCORE_CI_PRODUCT_KEY }}


### PR DESCRIPTION
Consolidated per-repo CI fixes for `6.0`. Refs pimcore/service-operations#1083, pimcore/DevOps-Tasks#47, pimcore/DevOps-Tasks#44.

**1. php-cs-fixer: remove pwn-request pattern** — `pull_request_target` + fork checkout + fork-controlled `.php-cs-fixer.dist.php` + `contents: write` + auto-commit, replaced by the push-only reusable caller already on `5.2`/`6.1` (byte-identical to `6.1`). Same as pimcore/tinymce-bundle#34.

**2. Static analysis: dead reference repointed** — the caller referenced `reusable-static-analysis-centralized.yaml`, retired 2025-12-09, so every run start-failed with zero jobs. Repointed to the unified pattern; this PR ran the repo's first passing PHPStan legs since December (8.3/lowest, 8.4/highest).

**3. Trigger hygiene (#44 ideas 1–3)** — push scoped to version branches, concurrency + cancel-in-progress, paths-ignore doc/assets/markdown.

Post-merge verification: php-cs-fixer fired on push to 6.0 and passed, no PR-triggered run; upstream merge 6.0→6.1 pushed directly (dfa479d), php-cs-fixer diff empty as predicted.